### PR TITLE
feat: widget range

### DIFF
--- a/src/components/JsonSchemaForm/index.tsx
+++ b/src/components/JsonSchemaForm/index.tsx
@@ -3,6 +3,7 @@ import './index.less';
 import Form from '@rjsf/bootstrap-4';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import validator from '@rjsf/validator-ajv8';
+import { WidgetProps } from '@rjsf/utils';
 
 interface FormProps {
   disabled: boolean,
@@ -20,8 +21,56 @@ interface FormProps {
   showErrorList?: boolean;
 }
 
+// 自定义 Range Widget，使用 Bootstrap 的 range input
+const RangeWidget = (props: WidgetProps) => {
+  const {
+    value,
+    onChange,
+    disabled,
+    readonly,
+    schema,
+    options,
+  } = props;
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = schema.type === 'integer'
+      ? parseInt(event.target.value, 10)
+      : parseFloat(event.target.value);
+    onChange(newValue);
+  };
+
+  const min = schema.minimum ?? options?.minimum ?? 0;
+  const max = schema.maximum ?? options?.maximum ?? 100;
+  const step = schema.multipleOf ?? options?.step ?? (schema.type === 'integer' ? 1 : 0.1);
+
+  return (
+    <div>
+      <input
+        type="range"
+        className="form-control-range"
+        value={value ?? min}
+        onChange={handleChange}
+        disabled={disabled || readonly}
+        min={min}
+        max={max}
+        step={step}
+      />
+      {options?.showValue !== false && (
+        <div className="mt-2">
+          <span>{value ?? min}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export default forwardRef((props: FormProps, ref) => {
   const formRef = useRef();
+
+  // 注册自定义 widgets
+  const widgets = {
+    range: RangeWidget,
+  };
 
   useImperativeHandle(
     ref,
@@ -51,6 +100,7 @@ export default forwardRef((props: FormProps, ref) => {
         liveValidate={props.liveValidate}
         showErrorList={props.showErrorList && 'bottom'}
         omitExtraData
+        widgets={widgets}
       >
         <div />
       </Form>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a custom Bootstrap-based range widget and register it in the JSON Schema Form.
> 
> - **Components**:
>   - **`src/components/JsonSchemaForm/index.tsx`**:
>     - Add custom `RangeWidget` using Bootstrap `input[type="range"]`, handling `min`/`max`/`step`, integer vs number, and optional value display.
>     - Register widget via `widgets = { range: RangeWidget }` and pass to `Form`.
>     - Import `WidgetProps` from `@rjsf/utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d6044b575952ca06c5728835e679268a77ccc8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->